### PR TITLE
Pass event to the database instead of blip colour

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -332,8 +332,8 @@ AddEventHandler('dd_outlawalerts:alertPlace', function(title, blipAlertTime, bli
 end)
 
 RegisterNetEvent('dd_outlawalerts:outlawBlip')
-AddEventHandler('dd_outlawalerts:outlawBlip', function(identifier, blipColour, connectedPlayers)
-	if PlayerData.job ~= nil and has_value(LEO, PlayerData.job.name) and blipColour ~= 0 then
+AddEventHandler('dd_outlawalerts:outlawBlip', function(identifier, event, connectedPlayers)
+	if PlayerData.job ~= nil and has_value(LEO, PlayerData.job.name) and event ~= "NULL" then
 		for k,v in pairs(connectedPlayers) do
 			if identifier == v then
 				ped = GetPlayerFromServerId(k)
@@ -345,7 +345,7 @@ AddEventHandler('dd_outlawalerts:outlawBlip', function(identifier, blipColour, c
 			local transO = 250
 			local blip = AddBlipForEntity(outped)
 			SetBlipSprite(blip, 270)
-			SetBlipColour(blip, blipColour)
+			SetBlipColour(blip, Config.Events[event].Colour)
 			SetBlipAlpha(blip, transO)
 			SetBlipAsShortRange(blip, 1)
 			
@@ -353,7 +353,7 @@ AddEventHandler('dd_outlawalerts:outlawBlip', function(identifier, blipColour, c
 			AddTextComponentSubstringPlayerName('Suspect')
 			EndTextCommandSetBlipName(blip)
 			while transO ~= 0 do
-				Wait(outlawTime * 4)
+				Wait(Config.Events[event].OutlawTime * 4)
 				transO = transO - 1
 				SetBlipAlpha(blip, transO)
 				if transO == 0 then
@@ -450,7 +450,7 @@ function alert(event, sender, receiver, eventPos)
 		end
 		if alertChance(ac) then
 			if Config.Events[event].Outlaw then
-				TriggerServerEvent('dd_outlawalerts:setOutlaw', Config.Events[event].Colour)
+				TriggerServerEvent('dd_outlawalerts:setOutlaw', event)
 			end
 			TriggerServerEvent('dd_outlawalerts:alertPos', event, Config.Events[event].BlipTime, Config.Events[event].Colour, eventPos.x, eventPos.y, eventPos.z)
 			TriggerServerEvent('dd_outlawalerts:eventInProgress', event, zone, sender, receiver, street1, street2, vehName, sex, plate, pcname, scname)

--- a/dd_outlawalerts.sql
+++ b/dd_outlawalerts.sql
@@ -3,5 +3,5 @@ INSERT INTO `items` (name, label, weight) VALUES
 ;
 
 ALTER TABLE `users`
-    ADD COLUMN `outlaw` TINYINT(100) 0 DEFAULT 0
+    ADD COLUMN `outlaw` varchar(100) NULL DEFAULT NULL
 ;

--- a/server/main.lua
+++ b/server/main.lua
@@ -147,11 +147,11 @@ function playSound(event, zone, sender, receiver)
 end
 
 RegisterServerEvent('dd_outlawalerts:setOutlaw')
-AddEventHandler('dd_outlawalerts:setOutlaw', function(blipColour)
+AddEventHandler('dd_outlawalerts:setOutlaw', function(event)
 	local identifier = GetPlayerIdentifier(source, 0)
-	MySQL.Async.execute('UPDATE users SET outlaw = @blipColour WHERE identifier = @identifier', {
+	MySQL.Async.execute('UPDATE users SET outlaw = @event WHERE identifier = @identifier', {
 		['@identifier'] = identifier,
-		['@blipColour'] = blipColour
+		['@event'] = event
 	})
 	Wait(1000)
 	TriggerEvent('dd_outlawalerts:getOutlaw', identifier)
@@ -162,12 +162,12 @@ AddEventHandler('dd_outlawalerts:getOutlaw', function(identifier)
 	MySQL.Async.fetchAll("SELECT identifier, outlaw FROM users WHERE identifier = @identifier", {
 		['@identifier'] = identifier
 	}, function(result)
-		blipColour = result[1].outlaw
-		if blipColour ~= 0 then
-			TriggerClientEvent('dd_outlawalerts:outlawBlip', -1, identifier, blipColour, connectedPlayers)
-			MySQL.Async.execute('UPDATE users SET outlaw = @blipColour WHERE identifier = @identifier', {
+		event = result[1].outlaw
+		if event ~= "NULL" then
+			TriggerClientEvent('dd_outlawalerts:outlawBlip', -1, identifier, event, connectedPlayers)
+			MySQL.Async.execute('UPDATE users SET outlaw = @event WHERE identifier = @identifier', {
 				['@identifier'] = identifier,
-				['@blipColour'] = 0
+				['@event'] = "NULL"
 			})
 		end
 	end)


### PR DESCRIPTION
Breaking database change

passes the event that has triggered the alert to the database instead of the colour so that OutlawTime in the config actually does something