### PR TITLE
Develop

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -429,9 +429,6 @@ function alert(event, sender, receiver, eventPos)
 	local pcname, scname = colourNames[tostring(pColour)], colourNames[tostring(sColour)]
 	local display = GetDisplayNameFromVehicleModel(GetEntityModel(veh))
 	local vehName = GetLabelText(display)
-	if vehName == "NULL" then
-		vehName = "vehicle"
-	end
 	if zone == nil then
 		zone = "San Andreas"
 	end
@@ -439,9 +436,9 @@ function alert(event, sender, receiver, eventPos)
 		receiver = Config.Zones[zone].Jurisdiction
 	end
 	if IsPedMale(ped) then
-		sex = "male"
+		sex = "Male"
 	elseif not IsPedMale(ped) then
-		sex = "female"
+		sex = "Female"
 	end
 	if Config.Events[event].Populated == false or Config.Zones[zone].Populated then
 		if ownerCheck(event, plate) then
@@ -453,7 +450,7 @@ function alert(event, sender, receiver, eventPos)
 			if Config.Events[event].Outlaw then
 				TriggerServerEvent('dd_outlawalerts:setOutlaw', event)
 			end
-			TriggerServerEvent('dd_outlawalerts:eventInProgress', event, zone, sender, receiver, eventPos, street1, street2, vehName, sex, plate, pcname, scname)
+			TriggerServerEvent('dd_outlawalerts:eventInProgress', event, zone, sender, receiver, eventPos, street1, street2, sex, vehName, plate, pcname, scname)
 		end
 	end
 	TriggerEvent('dd_outlawalerts:waitLoop', event)

--- a/client/main.lua
+++ b/client/main.lua
@@ -290,40 +290,41 @@ function alertChance(ac)
 end
 
 RegisterNetEvent('dd_outlawalerts:Notify')
-AddEventHandler('dd_outlawalerts:Notify', function(title, zone, receiver, msg)
+AddEventHandler('dd_outlawalerts:Notify', function(event, zone, receiver, msg, eventPos)
+	TriggerEvent('dd_outlawalerts:staticBlip', event, eventPos)
 	ESX.TriggerServerCallback('dd_outlawalerts:getItemAmount', function(quantity)
 		if PlayerData.job ~= nil then 
 			if quantity > 0 then
-				ESX.ShowAdvancedNotification(title, zone, msg, 'CHAR_CALL911', 7)
+				ESX.ShowAdvancedNotification(event, zone, msg, 'CHAR_CALL911', 7)
 			elseif PlayerData.job.name == receiver then
-				ESX.ShowAdvancedNotification(title, zone, msg, 'CHAR_CALL911', 7)
+				ESX.ShowAdvancedNotification(event, zone, msg, 'CHAR_CALL911', 7)
 			elseif receiver == "LEO" and has_value(LEO, PlayerData.job.name) then
-				ESX.ShowAdvancedNotification(title, zone, msg, 'CHAR_CALL911', 7)
+				ESX.ShowAdvancedNotification(event, zone, msg, 'CHAR_CALL911', 7)
 			end
 		end
 	end, 'scanner')
 end)
 
-RegisterNetEvent('dd_outlawalerts:alertPlace')
-AddEventHandler('dd_outlawalerts:alertPlace', function(title, blipAlertTime, blipColour, ax, ay, az)
+RegisterNetEvent('dd_outlawalerts:staticBlip')
+AddEventHandler('dd_outlawalerts:staticBlip', function(event, eventPos)
 	if PlayerData.job ~= nil then
 		if has_value(LEO, PlayerData.job.name) then
 			local trans = 250
-			local alertBlip = AddBlipForCoord(ax, ay, az)
-			SetBlipSprite(alertBlip, 1)
-			SetBlipColour(alertBlip, blipColour)
-			SetBlipAlpha(alertBlip, trans)
-			SetBlipAsShortRange(alertBlip, 0)
+			local staticBlip = AddBlipForCoord(eventPos.x, eventPos.y, eventPos.z)
+			SetBlipSprite(staticBlip, 1)
+			SetBlipColour(staticBlip, Config.Events[event].Colour)
+			SetBlipAlpha(staticBlip, trans)
+			SetBlipAsShortRange(staticBlip, 0)
 
 			BeginTextCommandSetBlipName('STRING')
 			AddTextComponentSubstringPlayerName(title)
-			EndTextCommandSetBlipName(alertBlip)
+			EndTextCommandSetBlipName(staticBlip)
 			while trans ~= 0 do
-				Wait(blipAlertTime * 4)
+				Wait(Config.Events[event].BlipTime * 4)
 				trans = trans - 1
-				SetBlipAlpha(alertBlip,  trans)
+				SetBlipAlpha(staticBlip,  trans)
 				if trans == 0 then
-					SetBlipSprite(alertBlip, 2)
+					SetBlipSprite(staticBlip, 2)
 					return 
 				end
 			end
@@ -452,8 +453,7 @@ function alert(event, sender, receiver, eventPos)
 			if Config.Events[event].Outlaw then
 				TriggerServerEvent('dd_outlawalerts:setOutlaw', event)
 			end
-			TriggerServerEvent('dd_outlawalerts:alertPos', event, Config.Events[event].BlipTime, Config.Events[event].Colour, eventPos.x, eventPos.y, eventPos.z)
-			TriggerServerEvent('dd_outlawalerts:eventInProgress', event, zone, sender, receiver, street1, street2, vehName, sex, plate, pcname, scname)
+			TriggerServerEvent('dd_outlawalerts:eventInProgress', event, zone, sender, receiver, eventPos, street1, street2, vehName, sex, plate, pcname, scname)
 		end
 	end
 	TriggerEvent('dd_outlawalerts:waitLoop', event)

--- a/config.lua
+++ b/config.lua
@@ -9,14 +9,14 @@ Config = {
                 "xand",
                 "street2"
             },
-            Colour = 1,
-            BlipTime = 120,
-            Outlaw = true,
-            OutlawTime = 120,
-            Chance = 50,
-            Populated = true,
-            OwnershipCheck = false,
-            Waittime = 5
+            Colour = 1, --sets the colour of both the static blip and the outlaw blip
+            BlipTime = 120, --the time it takes for the static blip to fade away to nothing
+            Outlaw = true, --sets whether an outlaw blip will be created for this event
+            OutlawTime = 120, --the time it takes for the outlaw blip to fade away to nothing
+            Chance = 50, --percentage that the event will trigger an alert
+            Populated = true, --sets whether the event needs to take place in a populated zone in order to trigger an alert
+            OwnershipCheck = false, --sets whether the ownership of the vehicle is taken into account for the alert chance
+            Waittime = 5 --sets the minimum time between alerts for this event for each player
         },
         ["Civil Disturbance"] = {
             Text = {

--- a/config.lua
+++ b/config.lua
@@ -4,9 +4,12 @@ Config = {
             Text = {
                 "~r~Shots fired ~w~by a ~r~",
                 "sex",
-                "atbetween",
+                "preveh",
+                "pcname",
+                "scname",
+                "vehName",
+                "plate",
                 "street1",
-                "xand",
                 "street2"
             },
             Colour = 1, --sets the colour of both the static blip and the outlaw blip
@@ -22,9 +25,7 @@ Config = {
             Text = {
                 "~r~Civil Disturbance ~w~involving a ~r~",
                 "sex",
-                "atbetween",
                 "street1",
-                "xand",
                 "street2"
             },
             Colour = 17,
@@ -39,12 +40,13 @@ Config = {
         ["Grand Theft Auto"] = {
             Text = {
                 "~r~Grand Theft Auto ~w~of a ~r~",
-                "veh",
+                "pcname",
+                "scname",
+                "vehName",
+                "plate",
                 "~w~ by a ~r~",
                 "sex",
-                "atbetween",
                 "street1",
-                "xand",
                 "street2"
             },
             Colour = 5,
@@ -58,13 +60,14 @@ Config = {
         },
         ["Vehicle Theft"] = {
             Text = {
-                "Attempted ~r~theft ~w~of a ~r~",
-                "veh",
+                "~r~Attempted Theft ~w~of a ~r~",
+                "pcname",
+                "scname",
+                "vehName",
+                "plate",
                 "~w~ by a ~r~",
                 "sex",
-                "atbetween",
                 "street1",
-                "xand",
                 "street2"
             },
             Colour = 5,
@@ -78,11 +81,12 @@ Config = {
         },
         ["Weaponized Vehicle"] = {
             Text = {
-                "Reports of a ~r~weaponized vehicle ~w~, a ~r~",
-                "veh",
-                "atbetween",
+                "Reports of a ~r~Weaponized Vehicle ~w~, a ~r~",
+                "pcname",
+                "scname",
+                "vehName",
+                "plate",
                 "street1",
-                "xand",
                 "street2"
             },
             Colour = 1,
@@ -96,13 +100,13 @@ Config = {
         },
         ["Car Chopping"] = {
             Text = {
-                "Suspected ~r~car chopping ~w~by a ~r~",
-                "veh",
+                "Suspected ~r~Car chopping ~w~of a ~r~",
+                "pcname",
+                "scname",
+                "vehName",
                 "~w~ by a ~r~",
                 "sex",
-                "atbetween",
                 "street1",
-                "xand",
                 "street2"
             },
             Colour = 5,
@@ -116,11 +120,9 @@ Config = {
         },
         ["Drug Deal"] = {
             Text = {
-                "Suspected ~r~drug deal ~w~by a ~r~",
+                "Suspected ~r~Drug Deal ~w~by a ~r~",
                 "sex",
-                "atbetween",
                 "street1",
-                "xand",
                 "street2"
             },
             Colour = 7,
@@ -136,9 +138,7 @@ Config = {
             Text = {
                 "~r~Bank Robbery ~w~by a ~r~",
                 "sex",
-                "atbetween",
                 "street1",
-                "xand",
                 "street2"
             },
             Colour = 8,
@@ -154,9 +154,7 @@ Config = {
             Text = {
                 "~r~Shop Robbery ~w~by a ~r~",
                 "sex",
-                "atbetween",
                 "street1",
-                "xand",
                 "street2"
             },
             Colour = 8,
@@ -170,10 +168,8 @@ Config = {
         },
         ["Explosion"] = {
             Text = {
-                "~r~Explosion ~w~reported ~r~",
-                "atbetween",
+                "~r~Explosion ~w~reported~r~",
                 "street1",
-                "xand",
                 "street2"
             },
             Colour = 1,
@@ -638,6 +634,12 @@ Config = {
     }
 }
 
+-- Settings
 Config.StealOwnChance = 10 -- Chance to trigger an alert for trying to steal your own car, compounds with other probabilities
 Config.AudioAlerts = true -- Set to false to disable audio alerts, they won't work anyway without the correct version of interactsound
 Config.UseItems = true -- Set to false if you don't want the scanner item functionality
+
+-- Extra Details
+Config.vehName = 50
+Config.Colours = 75
+Config.plate = 10

--- a/server/main.lua
+++ b/server/main.lua
@@ -89,29 +89,73 @@ function explosion(source, ev)
 	end
 end
 
-RegisterServerEvent('dd_outlawalerts:eventInProgress')
-AddEventHandler('dd_outlawalerts:eventInProgress', function(event, zone, sender, receiver, eventPos, street1, street2, vehName, sex, plate, pcname, scname)
-	local message = nil
-	if street2 == "" then
-		atbetween = " ~w~at ~r~"
-		xand = nil
-	elseif street2 ~= "" then
-		atbetween = " ~w~between ~r~"
-		xand = " ~w~and ~r~"
+function alertChance(ac)
+	local dr = math.random(1, 100)
+    if(dr <= ac)then
+		return true
 	end
+	return false
+end
+
+RegisterServerEvent('dd_outlawalerts:eventInProgress')
+AddEventHandler('dd_outlawalerts:eventInProgress', function(event, zone, sender, receiver, eventPos, street1, street2, sex, vehName, plate, pcname, scname)
+	local message = nil
+	
+	if vehName == "NULL" then
+		preveh = nil
+		pcname = nil
+		scname = nil
+		vehName = nil
+		plate = nil
+	else
+		preveh = "~w~ from a ~r~"
+		if pcname == scname then
+			scname = nil
+			pcname = pcname.." "
+		else
+			scname = "~w~ and ~r~"..scname.." "
+		end
+		plate = "~w~ with the plate ~y~"..plate
+		
+		if not alertChance(Config.vehName) then
+			vehName = "vehicle"
+			plate = nil
+		else
+			if not alertChance(Config.plate) then
+				plate = nil
+			end
+		end
+		if not alertChance(Config.colours) then
+			pcname = nil
+			scname = nil
+		end
+	end
+	
+	if street2 == "" then
+		street1 = " ~w~at ~r~"..street1
+		street2 = nil
+	else
+		street1 = " ~w~between ~r~"..street1
+		street2 = " ~w~and ~r~"..street2
+	end
+	
 	for k, v in pairs(Config.Events[event].Text) do
-		if v == "street1" then
+		if v == "sex" then
+			v = sex
+		elseif v == "preveh" then
+			v = preveh
+		elseif v == "pcname" then
+			v = pcname
+		elseif v == "scname" then
+			v = scname
+		elseif v == "vehName" then
+			v = vehName
+		elseif v == "plate" then
+			v = plate
+		elseif v == "street1" then
 			v = street1
 		elseif v == "street2" then
 			v = street2
-		elseif v == "sex" then
-			v = sex
-		elseif v == "veh" then
-			v = veh
-		elseif v == "atbetween" then
-			v = atbetween
-		elseif v == "xand" then
-			v = xand
 		end
 		if v ~= nil then
 			if message == nil then

--- a/server/main.lua
+++ b/server/main.lua
@@ -90,7 +90,7 @@ function explosion(source, ev)
 end
 
 RegisterServerEvent('dd_outlawalerts:eventInProgress')
-AddEventHandler('dd_outlawalerts:eventInProgress', function(event, zone, sender, receiver, street1, street2, veh, sex, plate, pcname, scname)
+AddEventHandler('dd_outlawalerts:eventInProgress', function(event, zone, sender, receiver, eventPos, street1, street2, vehName, sex, plate, pcname, scname)
 	local message = nil
 	if street2 == "" then
 		atbetween = " ~w~at ~r~"
@@ -121,7 +121,7 @@ AddEventHandler('dd_outlawalerts:eventInProgress', function(event, zone, sender,
 			end
 		end
 	end
-	TriggerClientEvent("dd_outlawalerts:Notify", -1, event, zone, receiver, message)
+	TriggerClientEvent("dd_outlawalerts:Notify", -1, event, zone, receiver, message, eventPos)
 	if Config.AudioAlerts then
 		playSound(event, zone, sender, receiver)
 	end
@@ -171,11 +171,6 @@ AddEventHandler('dd_outlawalerts:getOutlaw', function(identifier)
 			})
 		end
 	end)
-end)
-
-RegisterServerEvent('dd_outlawalerts:alertPos')
-AddEventHandler('dd_outlawalerts:alertPos', function(event, blipAlertTime, blipColour, ax, ay, az)
-	TriggerClientEvent('dd_outlawalerts:alertPlace', -1, event, blipAlertTime, blipColour, ax, ay, az )
 end)
 
 ESX.RegisterServerCallback('dd_outlawalerts:isVehicleOwner', function(source, cb, plate)


### PR DESCRIPTION
- Removed some redundant functions and tidied up passed variables 
- Added explanation to values in the config
- Added extra details to the text alerts which closes #2 

So regarding the extra details there are 3 parts, vehicle name, colour and number plate. The chance of each of these can be independently configured. If the vehicle name check fails then you just get `vehicle`, if the colour or number plate fails you get nothing for that variable. The vehicle name check needs to succeed for the number plate to have a chance of being included.

This change also influences text alerts where vehName was already used.