### PR TITLE
Add alert menu, vehicle class and small fixes

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -463,6 +463,7 @@ function alert(event, sender, receiver, eventPos)
 	local street2 = GetStreetNameFromHashKey(s2)
 	local zone = Config.Zones.Keys[GetNameOfZone(eventPos.x, eventPos.y, eventPos.z)]
 	local veh = GetVehiclePedIsUsing(ped)
+	local class = GetVehicleClass(veh)
 	local plate = GetVehicleNumberPlateText(veh)
 	local pColour, sColour = GetVehicleColours(veh)
 	local pcname, scname = colourNames[tostring(pColour)], colourNames[tostring(sColour)]
@@ -489,7 +490,7 @@ function alert(event, sender, receiver, eventPos)
 			if Config.Events[event].Outlaw and sender ~= "Officer" then
 				TriggerServerEvent('dd_outlawalerts:setOutlaw', event)
 			end
-			TriggerServerEvent('dd_outlawalerts:eventInProgress', event, zone, sender, receiver, eventPos, street1, street2, sex, vehName, plate, pcname, scname)
+			TriggerServerEvent('dd_outlawalerts:eventInProgress', event, zone, sender, receiver, eventPos, street1, street2, sex, vehName, plate, pcname, scname, class)
 		end
 	end
 	TriggerEvent('dd_outlawalerts:waitLoop', event)

--- a/client/main.lua
+++ b/client/main.lua
@@ -84,7 +84,7 @@ local weaponwhitelist = {
 }
 
 local vehicleblacklist = {
-	"FIRETRUK", "RIOT2", "POLMAV"
+	"FIRETRUK", "RIOT2", "POLMAV", "PREDATOR"
 }
 
 local colourNames = {
@@ -318,7 +318,7 @@ AddEventHandler('dd_outlawalerts:OpenAlertMenu', function()
 	local playerlocation = GetEntityForwardVector(PlayerPedId())
 	local playerCoords = GetEntityCoords(GetPlayerPed(-1))
 	
-	if data.current.value == "pursuit" then
+	if data.current.value == "Pursuit" then
 		
 	elseif data.current.value ~= nil then
 		alert(data.current.value, "Officer", Jurisdiction, nil)

--- a/client/main.lua
+++ b/client/main.lua
@@ -289,6 +289,45 @@ function alertChance(ac)
 	return false
 end
 
+RegisterNetEvent('dd_outlawalerts:OpenAlertMenu')
+AddEventHandler('dd_outlawalerts:OpenAlertMenu', function()
+	ESX.UI.Menu.CloseAll()
+
+	ESX.UI.Menu.Open('default', GetCurrentResourceName(), 'alert_menu',
+    {
+		title    = "Alert Menu",
+		align    = 'top-left',
+		elements = {
+			{label = "Pursuit", value = "Pursuit"},
+			{label = "Shots Fired", value = "Shots Fired"},
+			{label = "Civil Disturbance", value = "Civil Disturbance"},
+			{label = "Grand Theft Auto", value = "Grand Theft Auto"},
+			{label = "Vehicle Theft", value = "Vehicle Theft"},
+			{label = "Weaponized Vehicle", value = "Weaponized Vehicle"},
+			{label = "Car Chopping", value = "Car Chopping"},
+			{label = "Drug Deal", value = "Drug Deal"},
+			{label = "Bank Robbery", value = "Bank Robbery"},
+			{label = "Shop Robbery", value = "Shop Robbery"},
+		}
+	}, function(data, menu)
+	
+	local target, distance = ESX.Game.GetClosestPlayer()
+	local targetid = GetPlayerServerId(target)
+	local xPlayer = PlayerPedId()
+	local playerheading = GetEntityHeading(GetPlayerPed(-1))
+	local playerlocation = GetEntityForwardVector(PlayerPedId())
+	local playerCoords = GetEntityCoords(GetPlayerPed(-1))
+	
+	if data.current.value == "pursuit" then
+		
+	elseif data.current.value ~= nil then
+		alert(data.current.value, "Officer", Jurisdiction, nil)
+	end
+	end, function(data, menu)
+		menu.close()
+	end)
+end)
+
 RegisterNetEvent('dd_outlawalerts:Notify')
 AddEventHandler('dd_outlawalerts:Notify', function(event, zone, receiver, msg, eventPos)
 	TriggerEvent('dd_outlawalerts:staticBlip', event, eventPos)
@@ -440,14 +479,14 @@ function alert(event, sender, receiver, eventPos)
 	elseif not IsPedMale(ped) then
 		sex = "Female"
 	end
-	if Config.Events[event].Populated == false or Config.Zones[zone].Populated then
+	if Config.Events[event].Populated == false or Config.Zones[zone].Populated or sender == "Officer" then
 		if ownerCheck(event, plate) then
 			ac = (Config.Events[event].Chance/Config.stealOwnChance)
 		else
 			ac = Config.Events[event].Chance
 		end
-		if alertChance(ac) then
-			if Config.Events[event].Outlaw then
+		if alertChance(ac) or sender == "Officer" then
+			if Config.Events[event].Outlaw and sender ~= "Officer" then
 				TriggerServerEvent('dd_outlawalerts:setOutlaw', event)
 			end
 			TriggerServerEvent('dd_outlawalerts:eventInProgress', event, zone, sender, receiver, eventPos, street1, street2, sex, vehName, plate, pcname, scname)

--- a/config.lua
+++ b/config.lua
@@ -110,7 +110,7 @@ Config = {
         ["Weaponized Vehicle"] = {
             Text = {
                 ["Citizen"] = {
-                    "Reports of a ~r~Weaponized Vehicle ~w~, a ~r~",
+                    "Reports of a ~r~Weaponized Vehicle~w~, a ~r~",
                     "pcname",
                     "scname",
                     "vehName",

--- a/config.lua
+++ b/config.lua
@@ -2,15 +2,22 @@ Config = {
     Events = {
         ["Shots Fired"] = {
             Text = {
-                "~r~Shots fired ~w~by a ~r~",
-                "sex",
-                "preveh",
-                "pcname",
-                "scname",
-                "vehName",
-                "plate",
-                "street1",
-                "street2"
+                ["Citizen"] = {
+                    "~r~Shots fired ~w~by a ~r~",
+                    "sex",
+                    "preveh",
+                    "pcname",
+                    "scname",
+                    "vehName",
+                    "plate",
+                    "street1",
+                    "street2" 
+                },
+                ["Officer"] = {
+                    "~r~Shots fired",
+                    "street1",
+                    "street2" 
+                }
             },
             Colour = 1, --sets the colour of both the static blip and the outlaw blip
             BlipTime = 120, --the time it takes for the static blip to fade away to nothing
@@ -23,10 +30,17 @@ Config = {
         },
         ["Civil Disturbance"] = {
             Text = {
-                "~r~Civil Disturbance ~w~involving a ~r~",
-                "sex",
-                "street1",
-                "street2"
+                ["Citizen"] = {
+                    "~r~Civil Disturbance ~w~involving a ~r~",
+                    "sex",
+                    "street1",
+                    "street2"
+                },
+                ["Officer"] = {
+                    "~r~Civil Disturbance",
+                    "street1",
+                    "street2"
+                }
             },
             Colour = 17,
             BlipTime = 60,
@@ -39,15 +53,22 @@ Config = {
         },
         ["Grand Theft Auto"] = {
             Text = {
-                "~r~Grand Theft Auto ~w~of a ~r~",
-                "pcname",
-                "scname",
-                "vehName",
-                "plate",
-                "~w~ by a ~r~",
-                "sex",
-                "street1",
-                "street2"
+                ["Citizen"] = {
+                    "~r~Grand Theft Auto ~w~of a ~r~",
+                    "pcname",
+                    "scname",
+                    "vehName",
+                    "plate",
+                    "~w~ by a ~r~",
+                    "sex",
+                    "street1",
+                    "street2"
+                },
+                ["Officer"] = {
+                    "~r~Grand Theft Auto",
+                    "street1",
+                    "street2"
+                }
             },
             Colour = 5,
             BlipTime = 60,
@@ -60,15 +81,22 @@ Config = {
         },
         ["Vehicle Theft"] = {
             Text = {
-                "~r~Attempted Theft ~w~of a ~r~",
-                "pcname",
-                "scname",
-                "vehName",
-                "plate",
-                "~w~ by a ~r~",
-                "sex",
-                "street1",
-                "street2"
+                ["Citizen"] = {
+                    "~r~Attempted Theft ~w~of a ~r~",
+                    "pcname",
+                    "scname",
+                    "vehName",
+                    "plate",
+                    "~w~ by a ~r~",
+                    "sex",
+                    "street1",
+                    "street2"
+                },
+                ["Officer"] = {
+                    "~r~Attempted Theft",
+                    "street1",
+                    "street2"
+                }
             },
             Colour = 5,
             BlipTime = 60,
@@ -81,13 +109,20 @@ Config = {
         },
         ["Weaponized Vehicle"] = {
             Text = {
-                "Reports of a ~r~Weaponized Vehicle ~w~, a ~r~",
-                "pcname",
-                "scname",
-                "vehName",
-                "plate",
-                "street1",
-                "street2"
+                ["Citizen"] = {
+                    "Reports of a ~r~Weaponized Vehicle ~w~, a ~r~",
+                    "pcname",
+                    "scname",
+                    "vehName",
+                    "plate",
+                    "street1",
+                    "street2"
+                },
+                ["Officer"] = {
+                    "~r~Weaponized Vehicle",
+                    "street1",
+                    "street2"
+                }
             },
             Colour = 1,
             BlipTime = 60,
@@ -100,14 +135,21 @@ Config = {
         },
         ["Car Chopping"] = {
             Text = {
-                "Suspected ~r~Car chopping ~w~of a ~r~",
-                "pcname",
-                "scname",
-                "vehName",
-                "~w~ by a ~r~",
-                "sex",
-                "street1",
-                "street2"
+                ["Citizen"] = {
+                    "Suspected ~r~Car Chopping ~w~of a ~r~",
+                    "pcname",
+                    "scname",
+                    "vehName",
+                    "~w~ by a ~r~",
+                    "sex",
+                    "street1",
+                    "street2"
+                },
+                ["Officer"] = {
+                    "~r~Car Chopping",
+                    "street1",
+                    "street2"
+                }
             },
             Colour = 5,
             BlipTime = 60,
@@ -120,10 +162,17 @@ Config = {
         },
         ["Drug Deal"] = {
             Text = {
-                "Suspected ~r~Drug Deal ~w~by a ~r~",
-                "sex",
-                "street1",
-                "street2"
+                ["Citizen"] = {
+                    "Suspected ~r~Drug Deal ~w~by a ~r~",
+                    "sex",
+                    "street1",
+                    "street2"
+                },
+                ["Officer"] = {
+                    "~r~Drug Deal",
+                    "street1",
+                    "street2"
+                }
             },
             Colour = 7,
             BlipTime = 60,
@@ -136,10 +185,17 @@ Config = {
         },
         ["Bank Robbery"] = {
             Text = {
-                "~r~Bank Robbery ~w~by a ~r~",
-                "sex",
-                "street1",
-                "street2"
+                ["Citizen"] = {
+                    "~r~Bank Robbery ~w~by a ~r~",
+                    "sex",
+                    "street1",
+                    "street2"
+                },
+                ["Officer"] = {
+                    "~r~Bank Robbery",
+                    "street1",
+                    "street2"
+                }
             },
             Colour = 8,
             BlipTime = 300,
@@ -152,10 +208,17 @@ Config = {
         },
         ["Shop Robbery"] = {
             Text = {
-                "~r~Shop Robbery ~w~by a ~r~",
-                "sex",
-                "street1",
-                "street2"
+                ["Citizen"] = {
+                    "~r~Shop Robbery ~w~by a ~r~",
+                    "sex",
+                    "street1",
+                    "street2"
+                },
+                ["Officer"] = {
+                    "~r~Shop Robbery",
+                    "street1",
+                    "street2"
+                }
             },
             Colour = 8,
             BlipTime = 240,
@@ -168,9 +231,16 @@ Config = {
         },
         ["Explosion"] = {
             Text = {
-                "~r~Explosion ~w~reported~r~",
-                "street1",
-                "street2"
+                ["Citizen"] = {
+                    "~r~Explosion ~w~reported~r~",
+                    "street1",
+                    "street2"
+                },
+                ["Officer"] = {
+                    "~r~Explosion ~w~reported~r~",
+                    "street1",
+                    "street2"
+                }
             },
             Colour = 1,
             BlipTime = 120,

--- a/config.lua
+++ b/config.lua
@@ -712,4 +712,4 @@ Config.UseItems = true -- Set to false if you don't want the scanner item functi
 -- Extra Details
 Config.vehName = 50
 Config.Colours = 75
-Config.plate = 10
+Config.Plate = 10

--- a/server/main.lua
+++ b/server/main.lua
@@ -191,7 +191,7 @@ AddEventHandler('dd_outlawalerts:eventInProgress', function(event, zone, sender,
 		end
 	end
 	TriggerClientEvent("dd_outlawalerts:Notify", -1, event, zone, receiver, message, eventPos)
-	if Config.AudioAlerts then
+	if Sounds.Events[event] ~= nil and Config.AudioAlerts then
 		playSound(event, zone, sender, receiver)
 	end
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -139,7 +139,7 @@ AddEventHandler('dd_outlawalerts:eventInProgress', function(event, zone, sender,
 		street2 = " ~w~and ~r~"..street2
 	end
 	
-	for k, v in pairs(Config.Events[event].Text) do
+	for k, v in pairs(Config.Events[event].Text[sender]) do
 		if v == "sex" then
 			v = sex
 		elseif v == "preveh" then

--- a/server/main.lua
+++ b/server/main.lua
@@ -3,6 +3,31 @@ local connectedPlayers 	= {}
 local notExpl 			= {3, 13, 20, 21, 22, 39}
 local playing 			= false
 
+local Classes = {
+	[0] = "Compact Vehicle",
+	[1] = "Sedan",
+	[2] = "Sports Utility Vehicle",
+	[3] = "Coupe",
+	[4] = "Muscle Car",
+	[5] = "Sports Classic",
+	[6] = "Sports Car",
+	[7] = "Super Car",
+	[8] = "Motorcycle",
+	[9] = "Off-road Vehicle",
+	[10] = "Industrial Vehicle",
+	[11] = "Utility Vehicle",
+	[12] = "Van",
+	[13] = "Bicycle",
+	[14] = "Boat",
+	[15] = "Helicopter",
+	[16] = "Plane",
+	[17] = "Service Vehicle",
+	[18] = "Emergency Vehicle",
+	[19] = "Military Vehicle",
+	[20] = "Commercial Vehicle",
+	[21] = "Train"
+}
+
 TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 
 AddEventHandler('esx:playerLoaded', function(playerId, xPlayer)
@@ -98,7 +123,7 @@ function alertChance(ac)
 end
 
 RegisterServerEvent('dd_outlawalerts:eventInProgress')
-AddEventHandler('dd_outlawalerts:eventInProgress', function(event, zone, sender, receiver, eventPos, street1, street2, sex, vehName, plate, pcname, scname)
+AddEventHandler('dd_outlawalerts:eventInProgress', function(event, zone, sender, receiver, eventPos, street1, street2, sex, vehName, plate, pcname, scname, class)
 	local message = nil
 	
 	if vehName == "NULL" then
@@ -118,14 +143,14 @@ AddEventHandler('dd_outlawalerts:eventInProgress', function(event, zone, sender,
 		plate = "~w~ with the plate ~y~"..plate
 		
 		if not alertChance(Config.vehName) then
-			vehName = "vehicle"
+			vehName = Classes[class]
 			plate = nil
 		else
-			if not alertChance(Config.plate) then
+			if not alertChance(Config.Plate) then
 				plate = nil
 			end
 		end
-		if not alertChance(Config.colours) then
+		if not alertChance(Config.Colours) then
 			pcname = nil
 			scname = nil
 		end

--- a/server/main.lua
+++ b/server/main.lua
@@ -110,7 +110,7 @@ function explosion(source, ev)
 			eventPos.y = ev.posY
 			eventPos.z = ev.posZ
 		end
-		TriggerClientEvent('dd_outlawalerts:triggerAlert', scapegoat, "Explosion", citizen, Jurisdiction, eventPos)
+		TriggerClientEvent('dd_outlawalerts:triggerAlert', scapegoat, "Explosion", "Citizen", Jurisdiction, eventPos)
 	end
 end
 


### PR DESCRIPTION
- adds a menu to manually trigger alerts that can be accessed from another script, the alerts will have the sender `Officer` as it's assumed only cops will have access to this menu, it has a lot of information stripped out, closes #22 
- adds vehicle class to replace the generic vehicle text closes #29 
- adds a check to see if sounds exist for the event to stop the script from playing one file then erroring out